### PR TITLE
Implemented new health check config with a named endpoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Mark generated code
+src/ADL/** linguist-generated
+test/adl-gen/** linguist-generated

--- a/adl/config.adl
+++ b/adl/config.adl
@@ -84,9 +84,12 @@ struct HealthCheckConfig {
     /// a health check;
     String incomingPath;
 
-    /// The path to which will will proxy the above on the first
-    /// configured endpoint
+    /// The path to which will will proxy the above on the c2 deployment
     String outgoingPath;
+
+    // The name of the endpoint used for health checks. If nothing,
+    // the first endpoint (in name lexographic order will be used)
+    Maybe<EndPointLabel> endpoint = "nothing";
 };
 
 union MachineLabel {

--- a/src/ADL/Config.hs
+++ b/src/ADL/Config.hs
@@ -137,11 +137,12 @@ instance AdlValue EndPointType where
 data HealthCheckConfig = HealthCheckConfig
     { hc_incomingPath :: T.Text
     , hc_outgoingPath :: T.Text
+    , hc_endpoint :: (ADL.Sys.Types.Maybe ADL.Types.EndPointLabel)
     }
     deriving (Prelude.Eq,Prelude.Ord,Prelude.Show)
 
 mkHealthCheckConfig :: T.Text -> T.Text -> HealthCheckConfig
-mkHealthCheckConfig incomingPath outgoingPath = HealthCheckConfig incomingPath outgoingPath
+mkHealthCheckConfig incomingPath outgoingPath = HealthCheckConfig incomingPath outgoingPath Prelude.Nothing
 
 instance AdlValue HealthCheckConfig where
     atype _ = "config.HealthCheckConfig"
@@ -149,11 +150,13 @@ instance AdlValue HealthCheckConfig where
     jsonGen = genObject
         [ genField "incomingPath" hc_incomingPath
         , genField "outgoingPath" hc_outgoingPath
+        , genField "endpoint" hc_endpoint
         ]
     
     jsonParser = HealthCheckConfig
         <$> parseField "incomingPath"
         <*> parseField "outgoingPath"
+        <*> parseFieldDef "endpoint" Prelude.Nothing
 
 data JsonSource
     = Jsrc_file ADL.Types.FilePath
@@ -317,7 +320,7 @@ data ToolConfig = ToolConfig
     deriving (Prelude.Eq,Prelude.Ord,Prelude.Show)
 
 mkToolConfig :: BlobStoreConfig -> ToolConfig
-mkToolConfig releases = ToolConfig "/opt/deploys" "/opt/config" "/opt/var/log/camus2.log" "/opt" "/opt/var/www" "camus2cert" "" releases (stringMapFromList []) (stringMapFromList []) DeployMode_noproxy (Prelude.Just (HealthCheckConfig "/health-check" "/")) "1.16.1"
+mkToolConfig releases = ToolConfig "/opt/deploys" "/opt/config" "/opt/var/log/camus2.log" "/opt" "/opt/var/www" "camus2cert" "" releases (stringMapFromList []) (stringMapFromList []) DeployMode_noproxy (Prelude.Just (HealthCheckConfig "/health-check" "/" Prelude.Nothing)) "1.16.1"
 
 instance AdlValue ToolConfig where
     atype _ = "config.ToolConfig"
@@ -350,7 +353,7 @@ instance AdlValue ToolConfig where
         <*> parseFieldDef "configSources" (stringMapFromList [])
         <*> parseFieldDef "dynamicConfigSources" (stringMapFromList [])
         <*> parseFieldDef "deployMode" DeployMode_noproxy
-        <*> parseFieldDef "healthCheck" (Prelude.Just (HealthCheckConfig "/health-check" "/"))
+        <*> parseFieldDef "healthCheck" (Prelude.Just (HealthCheckConfig "/health-check" "/" Prelude.Nothing))
         <*> parseFieldDef "nginxDockerVersion" "1.16.1"
 
 data Verbosity

--- a/test/adl-gen/config.ts
+++ b/test/adl-gen/config.ts
@@ -68,7 +68,7 @@ export function makeToolConfig(
     configSources: input.configSources === undefined ? {} : input.configSources,
     dynamicConfigSources: input.dynamicConfigSources === undefined ? {} : input.dynamicConfigSources,
     deployMode: input.deployMode === undefined ? {kind : "noproxy"} : input.deployMode,
-    healthCheck: input.healthCheck === undefined ? {kind : "just", value : {incomingPath : "/health-check", outgoingPath : "/"}} : input.healthCheck,
+    healthCheck: input.healthCheck === undefined ? {kind : "just", value : {incomingPath : "/health-check", outgoingPath : "/", endpoint : {kind : "nothing"}}} : input.healthCheck,
     nginxDockerVersion: input.nginxDockerVersion === undefined ? "1.16.1" : input.nginxDockerVersion,
   };
 }
@@ -199,22 +199,25 @@ export interface HealthCheckConfig {
    * configured endpoint
    */
   outgoingPath: string;
+  endpoint: sys_types.Maybe<types.EndPointLabel>;
 }
 
 export function makeHealthCheckConfig(
   input: {
     incomingPath: string,
     outgoingPath: string,
+    endpoint?: sys_types.Maybe<types.EndPointLabel>,
   }
 ): HealthCheckConfig {
   return {
     incomingPath: input.incomingPath,
     outgoingPath: input.outgoingPath,
+    endpoint: input.endpoint === undefined ? {kind : "nothing"} : input.endpoint,
   };
 }
 
 const HealthCheckConfig_AST : ADL.ScopedDecl =
-  {"moduleName":"config","decl":{"annotations":[],"type_":{"kind":"struct_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"incomingPath","default":{"kind":"nothing"},"name":"incomingPath","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}},{"annotations":[],"serializedName":"outgoingPath","default":{"kind":"nothing"},"name":"outgoingPath","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}}]}},"name":"HealthCheckConfig","version":{"kind":"nothing"}}};
+  {"moduleName":"config","decl":{"annotations":[],"type_":{"kind":"struct_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"incomingPath","default":{"kind":"nothing"},"name":"incomingPath","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}},{"annotations":[],"serializedName":"outgoingPath","default":{"kind":"nothing"},"name":"outgoingPath","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}},{"annotations":[],"serializedName":"endpoint","default":{"kind":"just","value":"nothing"},"name":"endpoint","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.types","name":"Maybe"}},"parameters":[{"typeRef":{"kind":"reference","value":{"moduleName":"types","name":"EndPointLabel"}},"parameters":[]}]}}]}},"name":"HealthCheckConfig","version":{"kind":"nothing"}}};
 
 export const snHealthCheckConfig: ADL.ScopedName = {moduleName:"config", name:"HealthCheckConfig"};
 

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -277,7 +277,7 @@ export async function writeReleaseZip(
   zip: JSZip,
   name = "release.zip"
 ): Promise<void> {
-  console.log("start save releasezip", name);
+  console.log("saving releasezip", name);
   let dest = path.join(setup.dataDirs!.config.releases.value, name);
 
   if (setup.mode === "remote") {


### PR DESCRIPTION
This address the issue discovered in presien, where the healthcheck always wnt to the first endpoint ordered lexographically.