### PR TITLE
The default deploy name for a release no longer includes the zip suffix

### DIFF
--- a/test/httpd-proxy-local.test.ts
+++ b/test/httpd-proxy-local.test.ts
@@ -22,6 +22,7 @@ import {
   tearDownTest,
   zipAddReleaseJson,
   writeReleaseZip,
+  defaultDeployName
 } from "./testUtils";
 import { C2Exec } from "./C2Exec";
 import promiseRetry from "promise-retry";
@@ -137,7 +138,7 @@ describe(`Run httpd-proxy-local`, () => {
     for (const rel of releases) {
       console.log("c2 start release", rel.releaseName);
       await c2machine.start(rel.releaseName);
-      await c2machine.connect(rel.endpoint, rel.releaseName);
+      await c2machine.connect(rel.endpoint, defaultDeployName(rel.releaseName));
     }
 
     for (const rel of releases) {
@@ -192,7 +193,7 @@ describe(`Run httpd-proxy-local`, () => {
 
     for (const rel of releases) {
       await c2machine!.disconnect(rel.endpoint);
-      await c2machine!.stop(rel.releaseName);
+      await c2machine!.stop(defaultDeployName(rel.releaseName));
     }
 
     // for test cleanup

--- a/test/httpd-proxy-remote.test.ts
+++ b/test/httpd-proxy-remote.test.ts
@@ -23,6 +23,7 @@ import {
   writeReleaseZip,
   localstack,
   makeReleaseHttpd,
+  defaultDeployName,
 } from "./testUtils";
 import { C2Exec } from "./C2Exec";
 import promiseRetry from "promise-retry";
@@ -120,7 +121,7 @@ describe(`Run httpd-proxy-remote`, () => {
     for (const rel of releases) {
       console.log("c2 start release", rel.releaseName);
       await c2controller.start(rel.releaseName);
-      await c2controller.connect(rel.endpoint, rel.releaseName);
+      await c2controller.connect(rel.endpoint, defaultDeployName(rel.releaseName));
     }
 
     /// In deployment this happens on target machine periodically
@@ -158,7 +159,7 @@ describe(`Run httpd-proxy-remote`, () => {
 
     for (const rel of releases) {
       await c2controller!.disconnect(rel.endpoint);
-      await c2controller!.stop(rel.releaseName);
+      await c2controller!.stop(defaultDeployName(rel.releaseName));
     }
     await c2machine.slaveUpdate();
 

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -336,3 +336,7 @@ services:
   zip.file(testfilePath, testfileContents);
   return zip;
 }
+
+export function defaultDeployName(releasename: string): string {
+  return path.parse(releasename).name;
+}


### PR DESCRIPTION
This means that we no longer need to drop the suffix for the directory name,
avoid problems where different deploy names differ only in the suffix