### PR TITLE
Json ctx

### DIFF
--- a/adl/release.adl
+++ b/adl/release.adl
@@ -2,6 +2,7 @@ module release
 {
 
 import types.FilePath;
+import sys.types.Maybe;
 
 /// Configuration for a package to be customized
 /// when unpacked
@@ -16,6 +17,9 @@ struct ReleaseConfig
     // the template at release time. The file paths are
     // relative to the root of the unpacked release.
     StringMap<FilePath> configSources = {};
+
+    /// Save json context used for cfg templating to file
+    Maybe<String> ctxJson = "nothing";
 };
 
 };

--- a/camus2.cabal
+++ b/camus2.cabal
@@ -22,6 +22,7 @@ executable c2
   other-modules:       ADL.Core
                      , ADL.Core.Value
                      , ADL.Core.StringMap
+                     , ADL.Core.Map
                      , ADL.Core.Nullable
                      , ADL.Core.TypeToken
                      , ADL.Config

--- a/scripts/adlc
+++ b/scripts/adlc
@@ -5,7 +5,7 @@
 
 set -e
 
-adlversion=0.13.8
+adlversion=1.0
 
 if [ "$(uname)" == "Darwin" ]; then
   platform=osx

--- a/src/ADL/Core.hs
+++ b/src/ADL/Core.hs
@@ -1,5 +1,6 @@
 module ADL.Core(
   module ADL.Core.Value,
+  mapFromMapEntryList,
   StringMap(..),
   stringMapFromList,
   TypeToken(..),
@@ -8,6 +9,9 @@ module ADL.Core(
 
 import ADL.Core.Value
 import ADL.Core.StringMap(StringMap, fromList)
+import ADL.Core.Map(mapFromMapEntryList)
 import ADL.Core.TypeToken(TypeToken)
+import qualified Data.Map as M
 
 stringMapFromList = fromList
+

--- a/src/ADL/Core/Map.hs
+++ b/src/ADL/Core/Map.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings, ScopedTypeVariables #-}
+module ADL.Core.Map where
+
+import qualified Data.Map as M
+import qualified Data.Text as T
+
+import qualified Data.Proxy
+import ADL.Core.Value
+
+-- we hand declare sys.types.MapEntry here, so that the AdlValue instance for Data.Map.Map can depend on it
+data MapEntry k v = MapEntry
+    { mapEntry_key :: k
+    , mapEntry_value :: v
+    }
+    deriving (Prelude.Eq,Prelude.Ord,Prelude.Show)
+
+mkMapEntry :: k -> v -> MapEntry k v
+mkMapEntry key value = MapEntry key value
+
+instance (AdlValue k, AdlValue v) => AdlValue (MapEntry k v) where
+    atype _ = T.concat
+        [ "sys.types.MapEntry"
+        , "<", atype (Data.Proxy.Proxy :: Data.Proxy.Proxy k)
+        , ",", atype (Data.Proxy.Proxy :: Data.Proxy.Proxy v)
+        , ">" ]
+    
+    jsonGen = genObject
+        [ genField "k" mapEntry_key
+        , genField "v" mapEntry_value
+        ]
+    
+    jsonParser = MapEntry
+        <$> parseField "k"
+        <*> parseField "v"
+
+instance (AdlValue k, Ord k, AdlValue v) => AdlValue (M.Map k v) where
+  atype _ = atype (Data.Proxy.Proxy :: Data.Proxy.Proxy [MapEntry k v])
+  jsonGen = JsonGen (adlToJson . map (uncurry MapEntry) . M.toList)
+  jsonParser = mapFromMapEntryList <$> jsonParser
+
+mapFromMapEntryList :: (AdlValue k, Ord k, AdlValue v) => [MapEntry k v] -> M.Map k v
+mapFromMapEntryList = M.fromList . map (\(MapEntry k v) -> (k,v))

--- a/src/ADL/Core/Value.hs
+++ b/src/ADL/Core/Value.hs
@@ -34,7 +34,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
-import qualified Data.Map as M
 import qualified Data.Scientific as SC
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -354,11 +353,6 @@ instance forall t1 t2 . (AdlValue t1, AdlValue t2) => AdlValue (t1,t2) where
   jsonParser = (,)
     <$> parseField "v1"
     <*> parseField "v2"
-
-instance (AdlValue k, Ord k, AdlValue v) => AdlValue (M.Map k v) where
-  atype _ = atype (Proxy :: Proxy [(k,v)])
-  jsonGen = JsonGen (adlToJson . M.toList)
-  jsonParser = M.fromList <$> jsonParser
 
 instance (Ord v, AdlValue v) => AdlValue (S.Set v) where
   atype _ = atype (Proxy :: Proxy [v])

--- a/src/ADL/Release.hs
+++ b/src/ADL/Release.hs
@@ -7,6 +7,7 @@ module ADL.Release(
 import ADL.Core
 import Control.Applicative( (<$>), (<*>), (<|>) )
 import Prelude( ($) )
+import qualified ADL.Sys.Types
 import qualified ADL.Types
 import qualified Data.Aeson as JS
 import qualified Data.HashMap.Strict as HM
@@ -21,11 +22,12 @@ data ReleaseConfig = ReleaseConfig
     , rc_startCommand :: T.Text
     , rc_stopCommand :: T.Text
     , rc_configSources :: StringMap (ADL.Types.FilePath)
+    , rc_ctxJson :: (ADL.Sys.Types.Maybe T.Text)
     }
     deriving (Prelude.Eq,Prelude.Ord,Prelude.Show)
 
 mkReleaseConfig :: [ADL.Types.FilePath] -> T.Text -> T.Text -> T.Text -> ReleaseConfig
-mkReleaseConfig templates prestartCommand startCommand stopCommand = ReleaseConfig templates prestartCommand startCommand stopCommand (stringMapFromList [])
+mkReleaseConfig templates prestartCommand startCommand stopCommand = ReleaseConfig templates prestartCommand startCommand stopCommand (stringMapFromList []) Prelude.Nothing
 
 instance AdlValue ReleaseConfig where
     atype _ = "release.ReleaseConfig"
@@ -36,6 +38,7 @@ instance AdlValue ReleaseConfig where
         , genField "startCommand" rc_startCommand
         , genField "stopCommand" rc_stopCommand
         , genField "configSources" rc_configSources
+        , genField "ctxJson" rc_ctxJson
         ]
     
     jsonParser = ReleaseConfig
@@ -44,3 +47,4 @@ instance AdlValue ReleaseConfig where
         <*> parseField "startCommand"
         <*> parseField "stopCommand"
         <*> parseFieldDef "configSources" (stringMapFromList [])
+        <*> parseFieldDef "ctxJson" Prelude.Nothing

--- a/src/ADL/Sys/Types.hs
+++ b/src/ADL/Sys/Types.hs
@@ -1,60 +1,34 @@
-{-# LANGUAGE OverloadedStrings, ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
 module ADL.Sys.Types(
     Either,
-    Error,
     Map,
-    MapEntry(..),
+    MapEntry,
     Maybe,
     Pair,
     Result,
     Set,
-    mkMapEntry,
 ) where
 
 import ADL.Core
+import ADL.Core.Map(mapFromMapEntryList)
 import Control.Applicative( (<$>), (<*>), (<|>) )
 import Prelude( ($) )
+import qualified ADL.Core.Map
 import qualified Data.Aeson as JS
 import qualified Data.HashMap.Strict as HM
-import qualified Data.Map as Map
+import qualified Data.Map
 import qualified Data.Proxy
 import qualified Data.Set as Set
-import qualified Data.Text as T
 import qualified Prelude
 
 
 type Either = Prelude.Either
 
 
-type Error a  = Prelude.Either T.Text a
+type Map k v = Data.Map.Map k v
 
 
-type Map k v = Map.Map k v
-
-data MapEntry k v = MapEntry
-    { mapEntry_key :: k
-    , mapEntry_value :: v
-    }
-    deriving (Prelude.Eq,Prelude.Ord,Prelude.Show)
-
-mkMapEntry :: k -> v -> MapEntry k v
-mkMapEntry key value = MapEntry key value
-
-instance (AdlValue k, AdlValue v) => AdlValue (MapEntry k v) where
-    atype _ = T.concat
-        [ "sys.types.MapEntry"
-        , "<", atype (Data.Proxy.Proxy :: Data.Proxy.Proxy k)
-        , ",", atype (Data.Proxy.Proxy :: Data.Proxy.Proxy v)
-        , ">" ]
-    
-    jsonGen = genObject
-        [ genField "k" mapEntry_key
-        , genField "v" mapEntry_value
-        ]
-    
-    jsonParser = MapEntry
-        <$> parseField "k"
-        <*> parseField "v"
+type MapEntry k v = ADL.Core.Map.MapEntry k v
 
 
 type Maybe = Prelude.Maybe

--- a/test/adl-gen/config.ts
+++ b/test/adl-gen/config.ts
@@ -445,10 +445,8 @@ export function texprDynamicConfigOptions(): ADL.ATypeExpr<DynamicConfigOptions>
   return {value : {typeRef : {kind: "reference", value : snDynamicConfigOptions}, parameters : []}};
 }
 
-export enum Verbosity {
-  quiet,
-  noisy,
-}
+export type Verbosity = 'quiet' | 'noisy';
+export const valuesVerbosity : Verbosity[] = ['quiet', 'noisy'];
 
 const Verbosity_AST : ADL.ScopedDecl =
   {"moduleName":"config","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"quiet","default":{"kind":"nothing"},"name":"quiet","typeExpr":{"typeRef":{"kind":"primitive","value":"Void"},"parameters":[]}},{"annotations":[],"serializedName":"noisy","default":{"kind":"nothing"},"name":"noisy","typeExpr":{"typeRef":{"kind":"primitive","value":"Void"},"parameters":[]}}]}},"name":"Verbosity","version":{"kind":"nothing"}}};
@@ -506,7 +504,7 @@ export function makeLetsEncryptConfig(
     basedir: input.basedir,
     email: input.email,
     domains: input.domains,
-    verbosity: input.verbosity === undefined ? 0 : input.verbosity,
+    verbosity: input.verbosity === undefined ? "quiet" : input.verbosity,
   };
 }
 

--- a/test/adl-gen/release.ts
+++ b/test/adl-gen/release.ts
@@ -1,6 +1,7 @@
 /* @generated from adl module release */
 
 import * as ADL from './runtime/adl';
+import * as sys_types from './sys/types';
 import * as types from './types';
 
 /**
@@ -13,6 +14,10 @@ export interface ReleaseConfig {
   startCommand: string;
   stopCommand: string;
   configSources: {[key: string]: types.FilePath};
+  /**
+   * Save json context used for cfg templating to file
+   */
+  ctxJson: sys_types.Maybe<string>;
 }
 
 export function makeReleaseConfig(
@@ -22,6 +27,7 @@ export function makeReleaseConfig(
     startCommand: string,
     stopCommand: string,
     configSources?: {[key: string]: types.FilePath},
+    ctxJson?: sys_types.Maybe<string>,
   }
 ): ReleaseConfig {
   return {
@@ -30,11 +36,12 @@ export function makeReleaseConfig(
     startCommand: input.startCommand,
     stopCommand: input.stopCommand,
     configSources: input.configSources === undefined ? {} : input.configSources,
+    ctxJson: input.ctxJson === undefined ? {kind : "nothing"} : input.ctxJson,
   };
 }
 
 const ReleaseConfig_AST : ADL.ScopedDecl =
-  {"moduleName":"release","decl":{"annotations":[],"type_":{"kind":"struct_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"templates","default":{"kind":"nothing"},"name":"templates","typeExpr":{"typeRef":{"kind":"primitive","value":"Vector"},"parameters":[{"typeRef":{"kind":"reference","value":{"moduleName":"types","name":"FilePath"}},"parameters":[]}]}},{"annotations":[],"serializedName":"prestartCommand","default":{"kind":"nothing"},"name":"prestartCommand","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}},{"annotations":[],"serializedName":"startCommand","default":{"kind":"nothing"},"name":"startCommand","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}},{"annotations":[],"serializedName":"stopCommand","default":{"kind":"nothing"},"name":"stopCommand","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}},{"annotations":[],"serializedName":"configSources","default":{"kind":"just","value":{}},"name":"configSources","typeExpr":{"typeRef":{"kind":"primitive","value":"StringMap"},"parameters":[{"typeRef":{"kind":"reference","value":{"moduleName":"types","name":"FilePath"}},"parameters":[]}]}}]}},"name":"ReleaseConfig","version":{"kind":"nothing"}}};
+  {"moduleName":"release","decl":{"annotations":[],"type_":{"kind":"struct_","value":{"typeParams":[],"fields":[{"annotations":[],"serializedName":"templates","default":{"kind":"nothing"},"name":"templates","typeExpr":{"typeRef":{"kind":"primitive","value":"Vector"},"parameters":[{"typeRef":{"kind":"reference","value":{"moduleName":"types","name":"FilePath"}},"parameters":[]}]}},{"annotations":[],"serializedName":"prestartCommand","default":{"kind":"nothing"},"name":"prestartCommand","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}},{"annotations":[],"serializedName":"startCommand","default":{"kind":"nothing"},"name":"startCommand","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}},{"annotations":[],"serializedName":"stopCommand","default":{"kind":"nothing"},"name":"stopCommand","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}},{"annotations":[],"serializedName":"configSources","default":{"kind":"just","value":{}},"name":"configSources","typeExpr":{"typeRef":{"kind":"primitive","value":"StringMap"},"parameters":[{"typeRef":{"kind":"reference","value":{"moduleName":"types","name":"FilePath"}},"parameters":[]}]}},{"annotations":[],"serializedName":"ctxJson","default":{"kind":"just","value":"nothing"},"name":"ctxJson","typeExpr":{"typeRef":{"kind":"reference","value":{"moduleName":"sys.types","name":"Maybe"}},"parameters":[{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}]}}]}},"name":"ReleaseConfig","version":{"kind":"nothing"}}};
 
 export const snReleaseConfig: ADL.ScopedName = {moduleName:"release", name:"ReleaseConfig"};
 

--- a/test/adl-gen/runtime/sys/types.ts
+++ b/test/adl-gen/runtime/sys/types.ts
@@ -53,24 +53,6 @@ export interface MaybeOpts<T> {
 
 export function makeMaybe<T, K extends keyof MaybeOpts<T>>(kind: K, value: MaybeOpts<T>[K]) { return {kind, value}; }
 
-export interface Error_Value<T> {
-  kind: 'value';
-  value: T;
-}
-export interface Error_Error<_T> {
-  kind: 'error';
-  value: string;
-}
-
-export type Error<T> = Error_Value<T> | Error_Error<T>;
-
-export interface ErrorOpts<T> {
-  value: T;
-  error: string;
-}
-
-export function makeError<T, K extends keyof ErrorOpts<T>>(kind: K, value: ErrorOpts<T>[K]) { return {kind, value}; }
-
 export interface Result_Ok<T, _E> {
   kind: 'ok';
   value: T;
@@ -106,6 +88,6 @@ export function makeMapEntry<K, V>(
   };
 }
 
-export type Map<K, V> = Pair<K, V>[];
+export type Map<K, V> = MapEntry<K, V>[];
 
 export type Set<T> = T[];

--- a/test/adl-gen/sys/types.ts
+++ b/test/adl-gen/sys/types.ts
@@ -81,33 +81,6 @@ export function texprMaybe<T>(texprT : ADL.ATypeExpr<T>): ADL.ATypeExpr<Maybe<T>
   return {value : {typeRef : {kind: "reference", value : {moduleName : "sys.types",name : "Maybe"}}, parameters : [texprT.value]}};
 }
 
-export interface Error_Value<T> {
-  kind: 'value';
-  value: T;
-}
-export interface Error_Error<_T> {
-  kind: 'error';
-  value: string;
-}
-
-export type Error<T> = Error_Value<T> | Error_Error<T>;
-
-export interface ErrorOpts<T> {
-  value: T;
-  error: string;
-}
-
-export function makeError<T, K extends keyof ErrorOpts<T>>(kind: K, value: ErrorOpts<T>[K]) { return {kind, value}; }
-
-const Error_AST : ADL.ScopedDecl =
-  {"moduleName":"sys.types","decl":{"annotations":[],"type_":{"kind":"union_","value":{"typeParams":["T"],"fields":[{"annotations":[],"serializedName":"value","default":{"kind":"nothing"},"name":"value","typeExpr":{"typeRef":{"kind":"typeParam","value":"T"},"parameters":[]}},{"annotations":[],"serializedName":"error","default":{"kind":"nothing"},"name":"error","typeExpr":{"typeRef":{"kind":"primitive","value":"String"},"parameters":[]}}]}},"name":"Error","version":{"kind":"nothing"}}};
-
-export const snError: ADL.ScopedName = {moduleName:"sys.types", name:"Error"};
-
-export function texprError<T>(texprT : ADL.ATypeExpr<T>): ADL.ATypeExpr<Error<T>> {
-  return {value : {typeRef : {kind: "reference", value : {moduleName : "sys.types",name : "Error"}}, parameters : [texprT.value]}};
-}
-
 export interface Result_Ok<T, _E> {
   kind: 'ok';
   value: T;
@@ -161,10 +134,10 @@ export function texprMapEntry<K, V>(texprK : ADL.ATypeExpr<K>, texprV : ADL.ATyp
   return {value : {typeRef : {kind: "reference", value : {moduleName : "sys.types",name : "MapEntry"}}, parameters : [texprK.value, texprV.value]}};
 }
 
-export type Map<K, V> = Pair<K, V>[];
+export type Map<K, V> = MapEntry<K, V>[];
 
 const Map_AST : ADL.ScopedDecl =
-  {"moduleName":"sys.types","decl":{"annotations":[],"type_":{"kind":"newtype_","value":{"typeParams":["K","V"],"default":{"kind":"nothing"},"typeExpr":{"typeRef":{"kind":"primitive","value":"Vector"},"parameters":[{"typeRef":{"kind":"reference","value":{"moduleName":"sys.types","name":"Pair"}},"parameters":[{"typeRef":{"kind":"typeParam","value":"K"},"parameters":[]},{"typeRef":{"kind":"typeParam","value":"V"},"parameters":[]}]}]}}},"name":"Map","version":{"kind":"nothing"}}};
+  {"moduleName":"sys.types","decl":{"annotations":[],"type_":{"kind":"newtype_","value":{"typeParams":["K","V"],"default":{"kind":"nothing"},"typeExpr":{"typeRef":{"kind":"primitive","value":"Vector"},"parameters":[{"typeRef":{"kind":"reference","value":{"moduleName":"sys.types","name":"MapEntry"}},"parameters":[{"typeRef":{"kind":"typeParam","value":"K"},"parameters":[]},{"typeRef":{"kind":"typeParam","value":"V"},"parameters":[]}]}]}}},"name":"Map","version":{"kind":"nothing"}}};
 
 export const snMap: ADL.ScopedName = {moduleName:"sys.types", name:"Map"};
 
@@ -187,7 +160,6 @@ export const _AST_MAP: { [key: string]: ADL.ScopedDecl } = {
   "sys.types.Pair" : Pair_AST,
   "sys.types.Either" : Either_AST,
   "sys.types.Maybe" : Maybe_AST,
-  "sys.types.Error" : Error_AST,
   "sys.types.Result" : Result_AST,
   "sys.types.MapEntry" : MapEntry_AST,
   "sys.types.Map" : Map_AST,

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./testUtils";
 import { C2Exec } from "./C2Exec";
 
-/// Trivial release wit no contents except the release.json - actions just touch files
+/// Trivial release with no contents except the release.json - actions just touch files
 function makeRelease(setup: TestSetup): JSZip {
   const releaseConfig = makeReleaseConfig({
     templates: [],
@@ -64,19 +64,19 @@ for (const remoteMode of ["local", "remote"] as const) {
         await fsx.pathExists(
           path.join(dataDirs.machineOptDeploys, "release", "prestarted")
         )
-      );
+      ).toBeTruthy();
       expect(
         await fsx.pathExists(
           path.join(dataDirs.machineOptDeploys, "release", "started")
         )
-      );
+      ).toBeTruthy();
 
       await c2.stop("release.zip");
       expect(
         await fsx.pathExists(
           path.join(dataDirs.machineOptDeploys, "release", "stopped")
         )
-      );
+      ).toBeTruthy();
     });
   });
 }

--- a/test/httpd-proxy-local.test.ts
+++ b/test/httpd-proxy-local.test.ts
@@ -61,8 +61,8 @@ services:
       - ./:/usr/local/apache2/htdocs/:ro
   `
   );
-  zip.file(extrafilePath + '.tpl', '{{releasevals.v1}}'),
-  zip.file('releasevals.json', '{"v1" : "foobazbar"}'),
+  zip.file(extrafilePath + '.tpl', '{{releasevals.v1}}');
+  zip.file('releasevals.json', '{"v1" : "foobazbar"}');
   zip.file(testfilePath, testfileContents);
   return zip;
 }

--- a/test/httpd-proxy-local.test.ts
+++ b/test/httpd-proxy-local.test.ts
@@ -148,13 +148,8 @@ describe(`Run httpd-proxy-local`, () => {
     }
 
     for (const rel of releases) {
-      expect(
-        await fsx.pathExists(
-          path.join(dataDirs.machineOptDeploys, rel.releaseName, "started")
-        )
-      );
+      const deployName = defaultDeployName(rel.releaseName);
       console.log("http get file test start");
-
       const res = await promiseRetry(async (retry) => {
         try {
           console.log("try http get file test");
@@ -168,10 +163,17 @@ describe(`Run httpd-proxy-local`, () => {
         }
       });
 
-      expect(res);
+      expect(res).toBeTruthy();
       if (res) {
         expect(res.data).toEqual(rel.testcontents);
       }
+
+      // check for 'started' flag after retry loop:
+      expect(
+        await fsx.pathExists(
+          path.join(dataDirs.machineOptDeploys, deployName, "started")
+        )
+      ).toBeTruthy();
 
       const res2 = await promiseRetry(async (retry) => {
         try {
@@ -186,7 +188,7 @@ describe(`Run httpd-proxy-local`, () => {
         }
       });
 
-      expect(res2);
+      expect(res2).toBeTruthy();
       if (res2) {
         expect(res2.data).toEqual("foobazbar");
       }
@@ -206,7 +208,7 @@ describe(`Run httpd-proxy-local`, () => {
         }
       });
 
-      expect(res);
+      expect(res).toBeTruthy();
       if (res) {
         const healthcheckcontent = releases.find(r => r.endpoint === healthCheckEndpoint)?.testcontents;
         expect(res.data).toEqual(healthcheckcontent);
@@ -268,7 +270,7 @@ describe(`Run httpd-proxy-local`, () => {
         await fsx.pathExists(
           path.join(dataDirs.machineOptDeploys, dep.deployName, "started")
         )
-      );
+      ).toBeTruthy();
       console.log("http get file test start");
 
       const res = await promiseRetry(async (retry) => {
@@ -284,7 +286,7 @@ describe(`Run httpd-proxy-local`, () => {
         }
       });
 
-      expect(res);
+      expect(res).toBeTruthy();
       if (res) {
         expect(res.data).toEqual(testcontents);
       }

--- a/test/httpd-proxy-remote.test.ts
+++ b/test/httpd-proxy-remote.test.ts
@@ -129,11 +129,7 @@ describe(`Run httpd-proxy-remote`, () => {
     await c2machine.slaveUpdate();
 
     for (const rel of releases) {
-      expect(
-        await fsx.pathExists(
-          path.join(dataDirs.machineOptDeploys, rel.releaseName, "started")
-        )
-      );
+      const deployName = defaultDeployName(rel.releaseName);
       console.log("http get file test start");
 
       const res = await promiseRetry(async (retry) => {
@@ -149,10 +145,16 @@ describe(`Run httpd-proxy-remote`, () => {
         }
       });
 
-      expect(res);
+      expect(res).toBeTruthy();
       if (res) {
         expect(res.data).toEqual(rel.testcontents);
       }
+
+      expect(
+        await fsx.pathExists(
+          path.join(dataDirs.machineOptDeploys, deployName, "started")
+        )
+      ).toBeTruthy();
     }
 
     console.log("test OK");
@@ -220,7 +222,7 @@ describe(`Run httpd-proxy-remote`, () => {
         await fsx.pathExists(
           path.join(dataDirs.machineOptDeploys, dep.deployName, "started")
         )
-      );
+      ).toBeTruthy();
       console.log("http get file test start");
 
       const res = await promiseRetry(async (retry) => {

--- a/test/httpd.test.ts
+++ b/test/httpd.test.ts
@@ -67,7 +67,7 @@ for (const remoteMode of ["remote", "local"] as const) {
         await fsx.pathExists(
           path.join(dataDirs.machineOptDeploys, testSetup.randomstr, "started")
         )
-      );
+      ).toBeTruthy();
 
       console.log("http get file test start");
       const res = await promiseRetry(async (retry) => {
@@ -83,7 +83,7 @@ for (const remoteMode of ["remote", "local"] as const) {
         }
       });
 
-      expect(res);
+      expect(res).toBeTruthy();
       if (res) {
         expect(res.data).toEqual(testfileContents);
       }

--- a/test/json-ctx.test.ts
+++ b/test/json-ctx.test.ts
@@ -1,0 +1,142 @@
+import { makeReleaseConfig, ReleaseConfig } from "./adl-gen/release";
+import JSZip from "jszip";
+import fsx from "fs-extra";
+import { v4 as uuid } from "uuid";
+import path from "path";
+import { makeToolConfig, makeDeployMode, ToolConfig } from "./adl-gen/config";
+
+import {
+  TestSetup,
+  writeToolConfig,
+  setupTest,
+  tearDownTest,
+  zipAddReleaseJson,
+  writeReleaseZip,
+} from "./testUtils";
+import { C2Exec } from "./C2Exec";
+import { Maybe } from "./adl-gen/sys/types";
+
+const jsonValsTest = {
+  rva: {
+    aa : "aaaaa"
+  },
+  rvb: {
+    b : {
+      val: 'bbbb'
+    }
+  }
+};
+
+/// Trivial release with no contents except the release.json - actions just touch files
+function makeRelease(setup: TestSetup, ctxJson: Maybe<string>): JSZip {
+  let releaseConfig : ReleaseConfig;
+  const configSources = {
+    "rva" : "releaseValsA.json",
+    "rvb" : "releaseValsB.json",
+  };
+
+  if(ctxJson.kind === 'just') {
+    // test that the json context is exported ready before prestart
+    const ctxJsonFile = ctxJson.value;
+    releaseConfig = makeReleaseConfig({
+      templates: [],
+      prestartCommand: `[ -f ${ctxJsonFile} ] && touch prestarted`,
+      startCommand: `[ -f ${ctxJsonFile} ] && touch started`,
+      stopCommand: `[ -f ${ctxJsonFile} ] && touch stopped`,
+      configSources,
+      ctxJson
+    });
+  } else {
+    releaseConfig = makeReleaseConfig({
+      templates: [],
+      prestartCommand: `touch prestarted`,
+      startCommand: `touch started`,
+      stopCommand: `touch stopped`,
+      configSources,
+      ctxJson
+    });
+  }
+
+  const zip = new JSZip();
+  zipAddReleaseJson(zip, releaseConfig);
+  zip.file('releaseValsA.json', JSON.stringify(jsonValsTest.rva));
+  zip.file('releaseValsB.json', JSON.stringify(jsonValsTest.rvb));
+  return zip;
+}
+
+/// Trivial tool config with no special options
+function makeConfig(setup: TestSetup): ToolConfig {
+  return makeToolConfig({
+    ...setup.dataDirs!.config,
+    deployMode: makeDeployMode("noproxy", null),
+  });
+}
+
+const withJsonCtxVals : (Maybe<string> & {comment:string})[] = [
+  {
+    kind: "just", value: "ctx.json",
+    comment: "enabled-ctx-json",
+  },
+  {
+    kind: "just", value: "somethingElse.json",
+    comment: "enabled-something-custom",
+  },
+  {
+    kind: "nothing",
+    comment: "disabled",
+  }
+]
+
+for (const withJsonCtx of withJsonCtxVals) {
+  describe(`Json context enabled: ${withJsonCtx.comment}`, () => {
+    const testSetup: TestSetup = {
+      randomstr: uuid(),
+      dataDirs: null,
+      mode: "local",
+    };
+    beforeEach(async () => {
+      await setupTest(`json-ctx-export-${withJsonCtx.comment}`, testSetup);
+    });
+    afterEach(async () => {
+      await tearDownTest(testSetup);
+    });
+
+    test(`Config release and run - ${withJsonCtx.comment}`, async () => {
+      const dataDirs = testSetup.dataDirs!;
+      await writeReleaseZip(testSetup, makeRelease(testSetup, withJsonCtx));
+
+      await writeToolConfig(testSetup, makeConfig(testSetup), "single");
+
+      const c2 = new C2Exec(dataDirs, "single");
+
+      await c2.start("release.zip");
+      if(withJsonCtx.kind === 'just') {
+        const ctxJsonFilename = path.join(dataDirs.machineOptDeploys, "release", withJsonCtx.value);
+        expect(
+          await fsx.pathExists(ctxJsonFilename)
+        ).toBeTruthy();
+
+        const ctxJson = await fsx.readJSON(ctxJsonFilename);
+        expect(JSON.stringify(ctxJson)).toEqual(JSON.stringify(jsonValsTest));
+      }
+
+      expect(
+        await fsx.pathExists(
+          path.join(dataDirs.machineOptDeploys, "release", "prestarted")
+        )
+      ).toBeTruthy();
+      expect(
+        await fsx.pathExists(
+          path.join(dataDirs.machineOptDeploys, "release", "started")
+        )
+      ).toBeTruthy();
+
+      await c2.stop("release.zip");
+      expect(
+        await fsx.pathExists(
+          path.join(dataDirs.machineOptDeploys, "release", "stopped")
+        )
+      ).toBeTruthy();
+    });
+  });
+}


### PR DESCRIPTION
Opt-in option for c2 to export the json context to file.

Use case:
Moving responsibility for json context ingestion (/templating/json manipulation) into the app.

By default no behaviour is changed.
As an opt-in, release.json 
release.json can opt-in via specifying:
```
{
   "ctxJson" : {"just": "ctx.json"}
}
```

